### PR TITLE
Make TLS cert issuer name configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-e2e: dev-k3d dev-certmanager dev-rustfs dev-rqlite dev-storage ## Run end-t
 	echo -e "\033[33mRunning e2e tests with generic storage provider...\033[0m"
 	helm upgrade --install --create-namespace -n e2e --wait -f e2e/values-generic.yaml egress ./chart
 	STORAGE_PROVIDER="generic" go test ./e2e/... -count=1
+	$(MAKE) dev-destroy
 
 dev: dev-requirements dev-k3d dev-rustfs dev-rqlite ## Deploy dev env
 	docker buildx build --tag $(DEV_IMAGE) --target dev .

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ test-e2e: dev-k3d dev-certmanager dev-rustfs dev-rqlite dev-storage ## Run end-t
 	echo -e "\033[33mRunning e2e tests with generic storage provider...\033[0m"
 	helm upgrade --install --create-namespace -n e2e --wait -f e2e/values-generic.yaml egress ./chart
 	STORAGE_PROVIDER="generic" go test ./e2e/... -count=1
-	$(MAKE) dev-destroy
 
 dev: dev-requirements dev-k3d dev-rustfs dev-rqlite ## Deploy dev env
 	docker buildx build --tag $(DEV_IMAGE) --target dev .

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install using [helm](https://helm.sh/)
 
 ```bash
 helm install egress oci://ghcr.io/ucl-arc-tre/charts/egress \
-  --version 0.6.0
+  --version 0.7.0
 ```
 
 See [chart/values.yaml](./chart/values.yaml) for values.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: egress
 description: Helm chart for deploying the UCL ARC TRE egress service
 type: application
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.7.0
+appVersion: 0.7.0

--- a/chart/templates/certificate.yaml
+++ b/chart/templates/certificate.yaml
@@ -25,6 +25,6 @@ spec:
     - {{ $name }}.{{ $namespace }}.svc
     - {{ $name }}.{{ $namespace }}.svc.cluster.local
   issuerRef:
-    name: ca-issuer
+    name: {{ .Values.storage.generic.tls.issuerName | default "ca-issuer" }}
     kind: ClusterIssuer
 {{- end }}

--- a/chart/templates/certificate.yaml
+++ b/chart/templates/certificate.yaml
@@ -25,6 +25,6 @@ spec:
     - {{ $name }}.{{ $namespace }}.svc
     - {{ $name }}.{{ $namespace }}.svc.cluster.local
   issuerRef:
-    name: {{ .Values.storage.generic.tls.issuerName }}
+    name: {{ required "storage.generic.tls.issuerName is required" .Values.storage.generic.tls.issuerName }}
     kind: ClusterIssuer
 {{- end }}

--- a/chart/templates/certificate.yaml
+++ b/chart/templates/certificate.yaml
@@ -25,6 +25,6 @@ spec:
     - {{ $name }}.{{ $namespace }}.svc
     - {{ $name }}.{{ $namespace }}.svc.cluster.local
   issuerRef:
-    name: {{ .Values.storage.generic.tls.issuerName | default "ca-issuer" }}
+    name: {{ .Values.storage.generic.tls.issuerName }}
     kind: ClusterIssuer
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -43,6 +43,7 @@ storage:
     # mTLS configuration
     # Requires cert-manager to be already available in the cluster
     tls:
+      issuerName: null
       certManager:
         duration: null
         renewBefore: null

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,7 +44,7 @@ storage:
     # Requires cert-manager to be already available in the cluster
     tls:
       # Overrides the Certificate issuerRef.name (cert-manager ClusterIssuer).
-      # Defaults to ca-issuer when unset.
+      # Defaults to "ca-issuer"
       issuerName: "ca-issuer"
       certManager:
         duration: null

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -45,7 +45,7 @@ storage:
     tls:
       # Overrides the Certificate issuerRef.name (cert-manager ClusterIssuer).
       # Defaults to ca-issuer when unset.
-      issuerName: null
+      issuerName: "ca-issuer"
       certManager:
         duration: null
         renewBefore: null

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -43,6 +43,8 @@ storage:
     # mTLS configuration
     # Requires cert-manager to be already available in the cluster
     tls:
+      # Overrides the Certificate issuerRef.name (cert-manager ClusterIssuer).
+      # Defaults to ca-issuer when unset.
       issuerName: null
       certManager:
         duration: null

--- a/e2e/values-generic.yaml
+++ b/e2e/values-generic.yaml
@@ -15,6 +15,7 @@ storage:
   provider: generic
   generic:
     tls:
+      issuerName: ca-issuer
       certManager:
         duration: 720h # 30 days
         renewBefore: 240h # 10 days


### PR DESCRIPTION
Makes the TLS certificate issuer name configurable (defaulting to `"ca-issuer"`) so that downstream users can use custom issuer names.

### Checklist

- [x] Documentation has been updated
- [x] [e2e tests](https://github.com/ucl-arc-tre/egress/tree/main/e2e) have been added/updated, if required
- [x] Migration path is described, if required

### Risk assessment

<!--
If the risk score is non-zero please add a 'risk' label to the PR along
with the associated risk areas. See https://isms.arc.ucl.ac.uk/rism04-risk_assessment_and_treatment_procedure for guidance on risk assessing.

Impact is scored 0-5 with 0 being no impact and 5 being financial loss of >£15m and/or significant reputational damage to the institution.

Likelihood is scored 0-5 with 0 being impossible, 3 meaning it could occur in 2 years, and 5 being risk is occurring now.

If the risk score (Impact x Likelihood + Impact) exceeds 9 then this PR cannot be merged
unless accepted by risk management groups at all institutions.
-->

Statement: no impact
Impact: 0
Likelihood: NA
