### PR TITLE
fix: Guard against empty files location

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         exclude: openapi
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.12.1
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
         args:

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,16 @@ DEV_NODEPORT := 30001
 DEV_EXTERNAL_PORT := 8080
 DEV_RUSTFS_NODEPORT := 32000
 DEV_RUSTFS_EXTERNAL_PORT := 8081
-DEV_RQLITE_USERNAME := "dbuser"
-DEV_RQLITE_PASSWORD := "dbuser"
 DEV_KUBECONFIG_PATH := "kubeconfig.yaml"
 DEV_STORAGE_IMAGE := "localhost/storage-server:latest"
 DEV_STORAGE_ROOT := "/tmp/storage"
 DEV_IMAGE := "localhost/ucl-arc-tre-egress:dev"
 RELEASE_IMAGE := "localhost/ucl-arc-tre-egress:release"
+
+DEV_RUSTFS_ACCESS_KEY := "s3user"
+DEV_RUSTFS_SECRET_KEY := "s3user"
+DEV_RQLITE_USERNAME := "dbuser"
+DEV_RQLITE_PASSWORD := "dbuser"
 
 define assert_command_exists
 	if ! command -v $(1) &> /dev/null; then \
@@ -94,13 +97,14 @@ dev-certmanager: ## Install cert-manager and setup a CA for issuing mTLS certs
 dev-rustfs: ## Install rustfs as an S3 compatible object store
 	helm repo add rustfs https://charts.rustfs.com
 	helm upgrade rustfs rustfs/rustfs -n rustfs --create-namespace --install \
+	  --set secret.rustfs.access_key=$(DEV_RUSTFS_ACCESS_KEY) \
+	  --set secret.rustfs.secret_key=$(DEV_RUSTFS_SECRET_KEY) \
 	  --set mode.standalone.enabled=true \
 	  --set replicaCount=1 \
 	  --set gatewayApi.enabled=false \
 	  --set gatewayApi.gatewayClass="" \
 	  --set service.type=NodePort \
-	  --set mode.distributed.enabled=false \
-		--set secret.allowInsecureDefaults=true # required for dev
+	  --set mode.distributed.enabled=false
 
 dev-rqlite: ## Install rqlite for storing persistent state
 	helm repo add rqlite https://rqlite.github.io/helm-charts

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install using [helm](https://helm.sh/)
 
 ```bash
 helm install egress oci://ghcr.io/ucl-arc-tre/charts/egress \
-  --version 1.0.0
+  --version 1.0.1
 ```
 
 See [chart/values.yaml](./chart/values.yaml) for values.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: egress
 description: Helm chart for deploying the UCL ARC TRE egress service
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1

--- a/deploy/dev/values.yaml
+++ b/deploy/dev/values.yaml
@@ -28,8 +28,8 @@ storage:
   provider: s3
   s3:
     region: us-east-1
-    access_key_id: rustfsadmin
-    secret_access_key: rustfsadmin # pragma: allowlist secret
+    access_key_id: s3user
+    secret_access_key: s3user # pragma: allowlist secret
 
 db:
   provider: rqlite

--- a/e2e/s3.go
+++ b/e2e/s3.go
@@ -14,7 +14,11 @@ import (
 )
 
 const (
-	bucketName = "bucket1"
+	devEndpoint = "http://localhost:8081"
+	bucketName  = "bucket1"
+	accessKey   = "s3user"
+	secretKey   = "s3user"
+	region      = "us-east-1"
 )
 
 type S3Provider struct{}
@@ -37,11 +41,11 @@ func newS3Client() *awsS3.Client {
 		context.Background(),
 		awsConfig.WithCredentialsProvider(awsCredentials.StaticCredentialsProvider{
 			Value: aws.Credentials{
-				AccessKeyID:     "rustfsadmin",
-				SecretAccessKey: "rustfsadmin",
+				AccessKeyID:     accessKey,
+				SecretAccessKey: secretKey,
 			},
 		}),
-		awsConfig.WithRegion("us-east-1"),
+		awsConfig.WithRegion(region),
 	))
 	client := awsS3.NewFromConfig(
 		cfg,
@@ -56,7 +60,7 @@ type DevResolver struct{}
 func (r DevResolver) ResolveEndpoint(ctx context.Context, params awsS3.EndpointParameters) (
 	awsEndpoints.Endpoint, error,
 ) {
-	url, err := url.Parse("http://localhost:8081")
+	url, err := url.Parse(devEndpoint)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/s3.go
+++ b/e2e/s3.go
@@ -17,7 +17,7 @@ const (
 	devEndpoint = "http://localhost:8081"
 	bucketName  = "bucket1"
 	accessKey   = "s3user"
-	secretKey   = "s3user"
+	secretKey   = "s3user" // pragma: allowlist secret
 	region      = "us-east-1"
 )
 

--- a/e2e/values-s3.yaml
+++ b/e2e/values-s3.yaml
@@ -20,8 +20,8 @@ storage:
   provider: s3
   s3:
     region: us-east-1
-    access_key_id: rustfsadmin
-    secret_access_key: rustfsadmin # pragma: allowlist secret
+    access_key_id: s3user
+    secret_access_key: s3user # pragma: allowlist secret
 
 db:
   provider: rqlite

--- a/internal/handler/main-generic_test.go
+++ b/internal/handler/main-generic_test.go
@@ -46,6 +46,12 @@ func TestGetFilesGeneric(t *testing.T) {
 			expectedStatusCode: 520,
 		},
 		{
+			name:               "missing location",
+			body:               `{"files_location":""}`,
+			genericClient:      generic.MockClient{},
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
 			name: "ok",
 			body: `{"files_location":"http://storage.local"}`,
 			genericClient: generic.MockClient{

--- a/internal/handler/main_test.go
+++ b/internal/handler/main_test.go
@@ -52,6 +52,12 @@ func TestGetFiles(t *testing.T) {
 			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
+			name:               "empty location",
+			body:               `{"files_location":""}`,
+			s3client:           s3.MockClient{},
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
 			name: "ok",
 			body: `{"files_location":"s3://bucket"}`,
 			s3client: s3.MockClient{
@@ -160,7 +166,8 @@ func TestGetFileId(t *testing.T) {
 			approvals: map[types.FileId]types.Approval{
 				types.FileId(fileId1): {
 					UserId:      "user1",
-					Destination: "world"},
+					Destination: "world",
+				},
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       `{"message":"Required 1 approvals for destination trusted but only had 0"}`,

--- a/internal/storage/main.go
+++ b/internal/storage/main.go
@@ -7,6 +7,9 @@ import (
 )
 
 func ParseLocation(raw string) (*types.LocationURI, error) {
+	if raw == "" {
+		return nil, types.NewErrInvalidObjectF("location must not be empty")
+	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return nil, err

--- a/internal/storage/main_test.go
+++ b/internal/storage/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/ucl-arc-tre/egress/internal/types"
 )
 
 func TestBucketNameFromLocation(t *testing.T) {
@@ -20,4 +21,10 @@ func TestBucketNameFromLocation(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = location.BucketName()
 	assert.Error(t, err)
+}
+
+func TestParseLocationEmptyLocation(t *testing.T) {
+	_, err := ParseLocation("")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, types.ErrInvalidObject)
 }


### PR DESCRIPTION
Resolves a bug where the generic file server allows passing through an empty files location URL.

### Checklist

- [x] Documentation has been updated
- [x] [e2e tests](https://github.com/ucl-arc-tre/egress/tree/main/e2e) have been added/updated, if required
- [x] Migration path is described, if required

### Risk assessment

<!--
If the risk score is non-zero please add a 'risk' label to the PR along
with the associated risk areas. See https://isms.arc.ucl.ac.uk/rism04-risk_assessment_and_treatment_procedure for guidance on risk assessing.

Impact is scored 0-5 with 0 being no impact and 5 being financial loss of >£15m and/or significant reputational damage to the institution.

Likelihood is scored 0-5 with 0 being impossible, 3 meaning it could occur in 2 years, and 5 being risk is occurring now.

If the risk score (Impact x Likelihood + Impact) exceeds 9 then this PR cannot be merged
unless accepted by risk management groups at all institutions.
-->

Statement: bug fix, no impact
Impact: 0
Likelihood: NA
