### PR TITLE
Add IRSA support for S3 storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install using [helm](https://helm.sh/)
 
 ```bash
 helm install egress oci://ghcr.io/ucl-arc-tre/charts/egress \
-  --version 1.0.1
+  --version 1.1.0
 ```
 
 See [chart/values.yaml](./chart/values.yaml) for values.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: egress
 description: Helm chart for deploying the UCL ARC TRE egress service
 type: application
-version: 1.1.0-dev
-appVersion: 1.1.0-dev
+version: 1.1.0
+appVersion: 1.1.0

--- a/chart/README.md
+++ b/chart/README.md
@@ -49,11 +49,3 @@ the EKS cluster and an IAM role with a trust policy that allows the service acco
 (`system:serviceaccount:<namespace>:<serviceAccount.name>`) to assume it. See the
 [AWS IRSA documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
 for details.
-
-### Service account values
-
-| Value                          | Default          | Description                                                                 |
-| ------------------------------ | ---------------- | --------------------------------------------------------------------------- |
-| `serviceAccount.create`        | `false`          | Whether to create a `ServiceAccount` for the deployment. If `false` and `name` is unset, pods use the namespace's `default` SA. |
-| `serviceAccount.name`          | `null`           | Name of the ServiceAccount. Defaults to the release name when `create` is `true`; otherwise references an existing SA. |
-| `serviceAccount.annotations`   | `{}`             | Annotations to apply to the ServiceAccount (e.g. the IRSA role ARN).        |

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,1 +1,57 @@
 # Helm chart
+
+Helm chart for deploying the egress service. See [`values.yaml`](./values.yaml) for the full
+list of configurable values.
+
+## S3 authentication
+
+The S3 storage backend supports two authentication modes:
+
+### Static credentials
+
+Provide an access key pair via chart values:
+
+```yaml
+storage:
+  provider: s3
+  s3:
+    region: eu-west-2
+    access_key_id: AKIA...
+    secret_access_key: ...
+```
+
+### IAM Roles for Service Accounts (IRSA)
+
+On EKS, an IAM role can be assumed by the pod via a projected service account token, removing
+the need to manage long-lived AWS keys. To enable IRSA, leave `access_key_id` and
+`secret_access_key` unset and annotate the service account with the IAM role ARN to assume:
+
+```yaml
+storage:
+  provider: s3
+  s3:
+    region: eu-west-2
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<role-name>
+```
+
+When `serviceAccount.annotations` is non-empty, the chart sets
+`automountServiceAccountToken: true` on the pod so the projected token is available to the AWS
+SDK. Credential resolution then falls through to the SDK default chain (web identity token via
+the configured role).
+
+Prerequisites on the AWS side (to be configured on the client-side): an OIDC provider associated with
+the EKS cluster and an IAM role with a trust policy that allows the service account
+(`system:serviceaccount:<namespace>:<serviceAccount.name>`) to assume it. See the
+[AWS IRSA documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+for details.
+
+### Service account values
+
+| Value                          | Default          | Description                                                                 |
+| ------------------------------ | ---------------- | --------------------------------------------------------------------------- |
+| `serviceAccount.create`        | `true`           | Whether to create a `ServiceAccount` for the deployment.                    |
+| `serviceAccount.name`          | `.Release.Name`  | Name of the service account. Set this if `create` is `false` and reusing an existing one. |
+| `serviceAccount.annotations`   | `{}`             | Annotations to apply to the service account (e.g. the IRSA role ARN).       |

--- a/chart/README.md
+++ b/chart/README.md
@@ -24,7 +24,8 @@ storage:
 
 On EKS, an IAM role can be assumed by the pod via a projected service account token, removing
 the need to manage long-lived AWS keys. To enable IRSA, leave `access_key_id` and
-`secret_access_key` unset and annotate the service account with the IAM role ARN to assume:
+`secret_access_key` unset, enable ServiceAccount creation, and annotate it with the IAM role
+ARN to assume:
 
 ```yaml
 storage:
@@ -33,6 +34,7 @@ storage:
     region: eu-west-2
 
 serviceAccount:
+  create: true
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<role-name>
 ```
@@ -52,6 +54,6 @@ for details.
 
 | Value                          | Default          | Description                                                                 |
 | ------------------------------ | ---------------- | --------------------------------------------------------------------------- |
-| `serviceAccount.create`        | `true`           | Whether to create a `ServiceAccount` for the deployment.                    |
-| `serviceAccount.name`          | `.Release.Name`  | Name of the service account. Set this if `create` is `false` and reusing an existing one. |
-| `serviceAccount.annotations`   | `{}`             | Annotations to apply to the service account (e.g. the IRSA role ARN).       |
+| `serviceAccount.create`        | `false`          | Whether to create a `ServiceAccount` for the deployment. If `false` and `name` is unset, pods use the namespace's `default` SA. |
+| `serviceAccount.name`          | `null`           | Name of the ServiceAccount. Defaults to the release name when `create` is `true`; otherwise references an existing SA. |
+| `serviceAccount.annotations`   | `{}`             | Annotations to apply to the ServiceAccount (e.g. the IRSA role ARN).        |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -20,7 +20,8 @@ spec:
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ gt (len .Values.serviceAccount.annotations) 0 }} # required for IRSA
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
       containers:
         - name: "app"
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       # When create=true, use the created SA (defaulting its name to the release name).
       # When create=false but a name is set, reference that existing SA.
-      # Otherwise both lines are omitted and the pod uses the namespace's default SA.
+      # Otherwise when both lines are omitted the pod uses the namespace's default SA.
       serviceAccountName: {{ if .Values.serviceAccount.create }}{{ .Values.serviceAccount.name | default .Release.Name }}{{ else }}{{ .Values.serviceAccount.name }}{{ end }}
       automountServiceAccountToken: {{ gt (len .Values.serviceAccount.annotations) 0 }} # required if using IRSA
       {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -20,10 +20,13 @@ spec:
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      # When create=true, use the created SA (defaulting its name to the release name).
+      # When create=false but a name is set, reference that existing SA.
+      # Otherwise both lines are omitted and the pod uses the namespace's default SA.
+      serviceAccountName: {{ if .Values.serviceAccount.create }}{{ .Values.serviceAccount.name | default .Release.Name }}{{ else }}{{ .Values.serviceAccount.name }}{{ end }}
       automountServiceAccountToken: {{ gt (len .Values.serviceAccount.annotations) 0 }} # required if using IRSA
-      # If we create the ServiceAccount, default its name to the release name; otherwise the
-      # user must supply an existing ServiceAccount name to avoid referencing one that doesn't exist.
-      serviceAccountName: {{ if .Values.serviceAccount.create }}{{ .Values.serviceAccount.name | default .Release.Name }}{{ else }}{{ required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name }}{{ end }}
+      {{- end }}
       containers:
         - name: "app"
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
-      automountServiceAccountToken: {{ gt (len .Values.serviceAccount.annotations) 0 }} # required for IRSA
+      automountServiceAccountToken: {{ gt (len .Values.serviceAccount.annotations) 0 }} # required if using IRSA
       serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
       containers:
         - name: "app"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -21,7 +21,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: {{ gt (len .Values.serviceAccount.annotations) 0 }} # required if using IRSA
-      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
+      # If we create the ServiceAccount, default its name to the release name; otherwise the
+      # user must supply an existing ServiceAccount name to avoid referencing one that doesn't exist.
+      serviceAccountName: {{ if .Values.serviceAccount.create }}{{ .Values.serviceAccount.name | default .Release.Name }}{{ else }}{{ required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name }}{{ end }}
       containers:
         - name: "app"
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -18,8 +18,8 @@ stringData:
       {{- if eq .Values.storage.provider "s3" }}
       s3:
         region: {{ required "storage.s3.region is required" .Values.storage.s3.region }}
-        access_key_id: {{ required "storage.s3.access_key_id is required" .Values.storage.s3.access_key_id }}
-        secret_access_key: {{ required "storage.s3.secret_access_key is required" .Values.storage.s3.secret_access_key }}
+        access_key_id: {{ .Values.storage.s3.access_key_id }}
+        secret_access_key: {{ .Values.storage.s3.secret_access_key }}
       {{- end }}
     db:
       provider: {{ required "db.provider is required" .Values.db.provider }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
+  labels:
+    "app.kubernetes.io/name": {{ .Release.Name }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,7 +66,12 @@ auth:
     username: null
     password: null
 
+# Service Account for IRSA
 serviceAccount:
+  # Wether to create a new Service Account
   create: true
+  # Name for the Service Account, defaults to the deployment's name
   name: null
+  # Service Account annotations, e.g. the IRSA role ARN
+  # If non-empty, the Service Account token is auto-mounted in pods
   annotations: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -65,3 +65,8 @@ auth:
   basic:
     username: null
     password: null
+
+serviceAccount:
+  create: true
+  name: null
+  annotations: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -68,7 +68,7 @@ auth:
 
 # Service Account for IRSA
 serviceAccount:
-  # Wether to create a new Service Account
+  # Whether to create a new Service Account
   create: true
   # Name for the Service Account, defaults to the deployment's name
   name: null

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,12 +66,12 @@ auth:
     username: null
     password: null
 
-# Service Account for IRSA
+# Service Account for IRSA. By default no ServiceAccount is created or referenced and
+# pods use the namespace's default ServiceAccount. Set `create: true` to create one, or
+# set `name` to reference an existing one (e.g. to wire up IRSA).
 serviceAccount:
-  # Whether to create a new Service Account
-  create: true
-  # Name for the Service Account, defaults to the deployment's name
+  create: false
   name: null
-  # Service Account annotations, e.g. the IRSA role ARN
-  # If non-empty, the Service Account token is auto-mounted in pods
+  # ServiceAccount annotations, e.g. the IRSA role ARN.
+  # If non-empty, the ServiceAccount token is auto-mounted in pods.
   annotations: {}

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -135,7 +135,8 @@ graph TB
 
 ### Storage Backends
 - **S3**: AWS S3-compatible storage
-  - Requires: region, access_key_id, secret_access_key
+  - Requires: region
+  - Authentication: static `access_key_id`/`secret_access_key`, or IRSA on EKS (see [chart README](../../chart/README.md))
   - Supports: bucket-based file organisation
 
 ### Authentication/Authorization

--- a/internal/storage/s3/client.go
+++ b/internal/storage/s3/client.go
@@ -12,17 +12,22 @@ import (
 	"github.com/ucl-arc-tre/egress/internal/config"
 )
 
+// newClient generates a new API client for AWS S3, optionally configuring the AWS AccessKeyId and SecretAccessKey if provided.
 func newClient(s3Config config.S3StorageConfig) (*awsS3.Client, error) {
-	cfg, err := awsConfig.LoadDefaultConfig(
-		context.Background(),
-		awsConfig.WithCredentialsProvider(awsCredentials.StaticCredentialsProvider{
-			Value: aws.Credentials{
-				AccessKeyID:     s3Config.AccessKeyId,
-				SecretAccessKey: s3Config.SecretAccessKey,
-			},
-		}),
+	opts := []func(*awsConfig.LoadOptions) error{
 		awsConfig.WithRegion(s3Config.Region),
-	)
+	}
+	if s3Config.AccessKeyId != "" && s3Config.SecretAccessKey != "" {
+		opts = append(opts, awsConfig.WithCredentialsProvider(
+			awsCredentials.StaticCredentialsProvider{
+				Value: aws.Credentials{
+					AccessKeyID:     s3Config.AccessKeyId,
+					SecretAccessKey: s3Config.SecretAccessKey,
+				},
+			},
+		))
+	}
+	cfg, err := awsConfig.LoadDefaultConfig(context.Background(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring S3 client: %w", err)
 	}

--- a/internal/storage/s3/client_test.go
+++ b/internal/storage/s3/client_test.go
@@ -1,0 +1,25 @@
+package s3
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ucl-arc-tre/egress/internal/config"
+)
+
+func TestEmptyCredsLoadsDefaultConfig(t *testing.T) {
+	tmpConfigPath := path.Join(t.TempDir(), "config.yaml")
+	os.WriteFile(tmpConfigPath, []byte(""), 0o775)
+	config.InitWithPath(tmpConfigPath)
+
+	client, err := newClient(config.S3StorageConfig{Region: "eu-west-2"})
+	assert.NoError(t, err)
+
+	creds, err := client.Options().Credentials.Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "", creds.AccessKeyID)
+	assert.Equal(t, "", creds.SecretAccessKey)
+}

--- a/internal/storage/s3/client_test.go
+++ b/internal/storage/s3/client_test.go
@@ -1,11 +1,11 @@
 package s3
 
 import (
-	"context"
 	"os"
 	"path"
 	"testing"
 
+	awsCredentials "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/ucl-arc-tre/egress/internal/config"
 )
@@ -17,9 +17,10 @@ func TestEmptyCredsLoadsDefaultConfig(t *testing.T) {
 
 	client, err := newClient(config.S3StorageConfig{Region: "eu-west-2"})
 	assert.NoError(t, err)
+	assert.NotNil(t, client)
 
-	creds, err := client.Options().Credentials.Retrieve(context.Background())
-	assert.NoError(t, err)
-	assert.Equal(t, "", creds.AccessKeyID)
-	assert.Equal(t, "", creds.SecretAccessKey)
+	// When no creds are provided, the default credential chain should be used
+	// rather than a StaticCredentialsProvider.
+	_, isStatic := client.Options().Credentials.(*awsCredentials.StaticCredentialsProvider)
+	assert.False(t, isStatic, "expected default credentials chain, not StaticCredentialsProvider")
 }


### PR DESCRIPTION
## Resolves #73

Adds support for [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for the S3 storage backend.

### Checklist

- [x] Documentation has been updated
- [x] [e2e tests](https://github.com/ucl-arc-tre/egress/tree/main/e2e) have been added/updated, if required
- [x] Migration path is described, if required

### Risk assessment

<!--
If the risk score is non-zero please add a 'risk' label to the PR along
with the associated risk areas. See https://isms.arc.ucl.ac.uk/rism04-risk_assessment_and_treatment_procedure for guidance on risk assessing.

Impact is scored 0-5 with 0 being no impact and 5 being financial loss of >£15m and/or significant reputational damage to the institution.

Likelihood is scored 0-5 with 0 being impossible, 3 meaning it could occur in 2 years, and 5 being risk is occurring now.

If the risk score (Impact x Likelihood + Impact) exceeds 9 then this PR cannot be merged
unless accepted by risk management groups at all institutions.
-->

Statement: Adds support for using IRSA to manage AWS credentials, which lowers risk. No impact.
Impact: 0
Likelihood: NA
