### PR TITLE
add swagger request validation

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -71,6 +71,7 @@ func canListFiles() bool {
 	if err != nil {
 		return false
 	}
+	req.Header.Add("Content-Type", "application/json")
 	req.SetBasicAuth(username, password)
 	resp, err := newHTTPClient().Do(req)
 	return err == nil && resp.StatusCode == http.StatusOK
@@ -125,6 +126,14 @@ func TestEndpointResponseCodes(t *testing.T) {
 			method: http.MethodGet,
 			url:    fmt.Sprintf("%s/%s/files/%s", baseApiUrl, projectId, fileId),
 			body:   strings.NewReader(`{"n}`),
+
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:   "GetFileNoBocyJson",
+			method: http.MethodGet,
+			url:    fmt.Sprintf("%s/%s/files/%s", baseApiUrl, projectId, fileId),
+			body:   nil,
 
 			expectedStatusCode: http.StatusBadRequest,
 		},
@@ -643,6 +652,7 @@ func listFiles(t *testing.T, projectId string) PartialListFilesResponse {
 		makeRequestBodyF(`{"files_location": "%s"}`, filesLocation),
 	))
 	req.SetBasicAuth(username, password)
+	req.Header.Set("Content-Type", "application/json")
 	res := must(client.Do(req))
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
@@ -724,6 +734,7 @@ func download(
 			comment,
 		),
 	))
+	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(username, password)
 	res := must(client.Do(req))
 
@@ -741,6 +752,7 @@ func makeRequest(t *testing.T) *http.Request {
 		fmt.Sprintf("%s/%s/files", baseApiUrl, projectId),
 		makeRequestBodyF(`{"files_location": "%s"}`, filesLocation),
 	))
+	req.Header.Set("Content-Type", "application/json")
 	return req
 }
 

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -130,7 +130,7 @@ func TestEndpointResponseCodes(t *testing.T) {
 			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
-			name:   "GetFileNoBocyJson",
+			name:   "GetFileNoBodyJson",
 			method: http.MethodGet,
 			url:    fmt.Sprintf("%s/%s/files/%s", baseApiUrl, projectId, fileId),
 			body:   nil,

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/v2 v2.3.5
 	github.com/lestrrat-go/jwx/v3 v3.1.1
+	github.com/oapi-codegen/gin-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.4.1
 	github.com/rqlite/gorqlite v0.0.0-20260504155303-50d445fd0ab9
 	github.com/rs/zerolog v1.35.1
@@ -57,6 +58,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -204,6 +206,8 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oapi-codegen/gin-middleware v1.0.2 h1:/H99UzvHQAUxXK8pzdcGAZgjCVeXdFDAUUWaJT0k0eI=
+github.com/oapi-codegen/gin-middleware v1.0.2/go.mod h1:2HJDQjH8jzK2/k/VKcWl+/T41H7ai2bKa6dN3AA2GpA=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/oapi-codegen/v2 v2.7.0 h1:/8daqIYZfwnsHEAZdHUu9m0D5LA+5DoJCP7zLlT5Cs0=

--- a/internal/handler/main_test.go
+++ b/internal/handler/main_test.go
@@ -425,6 +425,7 @@ func TestGetEvents(t *testing.T) {
 	// Log the events
 	for _, e := range sourceEvents {
 		err := e.runner(types.ProjectId(projectId), e.fileId, e.userId, e.destination, e.comment)
+		time.Sleep(10 * time.Millisecond)
 		assert.NoError(t, err)
 	}
 
@@ -463,6 +464,8 @@ func TestGetEvents(t *testing.T) {
 
 	// Verify ordering of the events
 	for i := 1; i < len(events); i++ {
-		assert.True(t, events[i].Datetime.After(events[i-1].Datetime))
+		previousEventAt := events[i-1].Datetime
+		currentEventAt := events[i].Datetime
+		assert.True(t, currentEventAt.After(previousEventAt), fmt.Sprintf("%v was before %v", currentEventAt, previousEventAt))
 	}
 }

--- a/internal/middleware/main.go
+++ b/internal/middleware/main.go
@@ -13,6 +13,7 @@ type authFunction func(*gin.Context)
 func All() []openapi.MiddlewareFunc {
 	return []openapi.MiddlewareFunc{
 		authMiddleware(),
+		swagger(),
 	}
 }
 

--- a/internal/middleware/main.go
+++ b/internal/middleware/main.go
@@ -13,7 +13,7 @@ type authFunction func(*gin.Context)
 func All() []openapi.MiddlewareFunc {
 	return []openapi.MiddlewareFunc{
 		authMiddleware(),
-		swagger(),
+		swaggerMiddleware(),
 	}
 }
 

--- a/internal/middleware/swagger.go
+++ b/internal/middleware/swagger.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/gin-gonic/gin"
+	ginmiddleware "github.com/oapi-codegen/gin-middleware"
+	"github.com/rs/zerolog/log"
+	"github.com/ucl-arc-tre/egress/internal/openapi"
+)
+
+func swagger() openapi.MiddlewareFunc {
+	swagger, err := openapi.GetSpec()
+	if err != nil {
+		panic(fmt.Sprintf("Error loading swagger spec\n: %s", err))
+	}
+	options := ginmiddleware.Options{
+		ErrorHandler: func(ctx *gin.Context, message string, statusCode int) {
+			log.Debug().Int("statusCode", statusCode).Msg(message)
+			ctx.AbortWithStatusJSON(statusCode, openapi.ErrorResponse{
+				Message: message,
+			})
+		},
+		Options: openapi3filter.Options{
+			// Authentication is handled with custom middleware. Noop to satisfy swagger
+			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
+		},
+	}
+	validator := ginmiddleware.OapiRequestValidatorWithOptions(swagger, &options)
+	return openapi.MiddlewareFunc(validator)
+}

--- a/internal/middleware/swagger.go
+++ b/internal/middleware/swagger.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ucl-arc-tre/egress/internal/openapi"
 )
 
-func swagger() openapi.MiddlewareFunc {
+func swaggerMiddleware() openapi.MiddlewareFunc {
 	swagger, err := openapi.GetSpec()
 	if err != nil {
 		panic(fmt.Sprintf("Error loading swagger spec\n: %s", err))


### PR DESCRIPTION
## Resolves #79

Adds validation of the openapi spec to default middleware using https://github.com/oapi-codegen/gin-middleware.

Drive by:

- Adds some explicit `Content-Type: application/json` to e2e requests
- Fixes the main handler tests on my machine

### Checklist

- n/a Documentation has been updated
- [x] [e2e tests](https://github.com/ucl-arc-tre/egress/tree/main/e2e) have been added/updated, if required
- [x] Migration path is described, if required

### Risk assessment

Statement: No impact as far as I can see. Only makes server responses more helpful
Impact: n/a
Likelihood: n/a
