### PR TITLE
fix: Incorrect comment associated with approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install using [helm](https://helm.sh/)
 
 ```bash
 helm install egress oci://ghcr.io/ucl-arc-tre/charts/egress \
-  --version 1.1.0
+  --version 1.2.0
 ```
 
 See [chart/values.yaml](./chart/values.yaml) for values.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: egress
 description: Helm chart for deploying the UCL ARC TRE egress service
 type: application
-version: 1.2.0-dev
-appVersion: 1.2.0-dev
+version: 1.2.0
+appVersion: 1.2.0

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -295,14 +295,14 @@ func TestMultipleApprovals(t *testing.T) {
 
 	// Approve file again with same {userId,destination}
 	// Approve is not idempotent, but approvals are deduped on
-	// {userId,desitnation}, so only 1 approval is returned
+	// {userId,destination}, so only 1 approval is returned, carrying the latest comment
 	approve(t, projectId, fileId, userId, destinationTrusted, commentApprove2)
 	files = listFiles(t, projectId)
 	approvedFile, _ = files.FileById(fileId)
 	assert.Len(t, approvedFile.Approvals, 1)
 	assert.Equal(t, userId, approvedFile.Approvals[0].UserId)
 	assert.Equal(t, destinationTrusted, approvedFile.Approvals[0].Destination)
-	assert.Equal(t, commentApprove1, approvedFile.Approvals[0].Comment)
+	assert.Equal(t, commentApprove2, approvedFile.Approvals[0].Comment)
 }
 
 func TestApproveToMultipleDestinations(t *testing.T) {

--- a/internal/db/inmemory/main_test.go
+++ b/internal/db/inmemory/main_test.go
@@ -56,10 +56,10 @@ func TestMultipleApprovals(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, approvals[fileId], 1)
 
-	// Comment of first approval returned
+	// Comment of the latest approval is returned (issue #78)
 	assert.Equal(t, userId1, approvals[fileId][0].UserId)
 	assert.Equal(t, destTrusted, approvals[fileId][0].Destination)
-	assert.Equal(t, commentApprove1, approvals[fileId][0].Comment)
+	assert.Equal(t, commentApprove2, approvals[fileId][0].Comment)
 }
 
 func TestApproveToMultipleDestinations(t *testing.T) {

--- a/internal/types/main.go
+++ b/internal/types/main.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"sort"
 	"time"
 )
 
@@ -52,8 +53,7 @@ type FileEvents []Event
 // Get approvals of a file
 // Multiple approvals with the same {UserId, Destination} are de-duplicated
 // A rejection that comes after an approval cancels that approval
-// Events must be chronologically ordered when this method is called and
-// the order is maintained in the filtered approval list
+// Events are sorted chronologically by Time before processing
 func (fe FileEvents) Approvals() FileApprovals {
 	type approvalKey struct {
 		userId      UserId
@@ -63,7 +63,13 @@ func (fe FileEvents) Approvals() FileApprovals {
 	approved := map[approvalKey]bool{}
 	order := []approvalKey{}
 
-	for _, e := range fe {
+	sorted := make(FileEvents, len(fe))
+	copy(sorted, fe)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Time.Before(sorted[j].Time)
+	})
+
+	for _, e := range sorted {
 		if e.Action != EventActionApproval && e.Action != EventActionRejection {
 			continue
 		}

--- a/internal/types/main.go
+++ b/internal/types/main.go
@@ -59,25 +59,28 @@ func (fe FileEvents) Approvals() FileApprovals {
 		userId      UserId
 		destination Destination
 	}
-	filter := map[approvalKey]bool{}
-	order := []Approval{}
+	latest := map[approvalKey]Approval{}
+	approved := map[approvalKey]bool{}
+	order := []approvalKey{}
 
 	for _, e := range fe {
 		if e.Action != EventActionApproval && e.Action != EventActionRejection {
 			continue
 		}
 		key := approvalKey{userId: e.UserId, destination: e.Destination}
-		if _, got := filter[key]; !got {
-			order = append(order, Approval(e.EventDetails))
+		if _, seen := latest[key]; !seen {
+			order = append(order, key)
 		}
-		filter[key] = e.Action == EventActionApproval
+		// Keep the most recent details so the returned approval reflects the
+		// latest approval's comment, not the first one for this key
+		latest[key] = Approval(e.EventDetails)
+		approved[key] = e.Action == EventActionApproval
 	}
-	// Return filtered approvals in same the order as input
+	// Return filtered approvals in the same order as input
 	approvals := FileApprovals{}
-	for _, ap := range order {
-		key := approvalKey{userId: ap.UserId, destination: ap.Destination}
-		if filter[key] {
-			approvals = append(approvals, ap)
+	for _, key := range order {
+		if approved[key] {
+			approvals = append(approvals, latest[key])
 		}
 	}
 	return approvals

--- a/internal/types/main_test.go
+++ b/internal/types/main_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -88,6 +89,15 @@ func TestFileEvents_Approvals(t *testing.T) {
 				{UserId: user2, Destination: dest1, Comment: "u2d1-b"},
 			},
 		},
+		{
+			name: "events are chronologically ordered",
+			events: FileEvents{
+				// Approval happened after the rejection, but comes first in the slice
+				approveAt(user1, dest1, time.Unix(3, 0)),
+				rejectAt(user1, dest1, time.Unix(1, 0)),
+			},
+			expected: FileApprovals{{UserId: user1, Destination: dest1}},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -122,5 +132,21 @@ func rejectWithComment(user UserId, dest Destination, comment string) Event {
 	return Event{
 		Action:       EventActionRejection,
 		EventDetails: EventDetails{UserId: user, Destination: dest, Comment: comment},
+	}
+}
+
+func approveAt(user UserId, dest Destination, t time.Time) Event {
+	return Event{
+		Action:       EventActionApproval,
+		EventDetails: EventDetails{UserId: user, Destination: dest},
+		Time:         t,
+	}
+}
+
+func rejectAt(user UserId, dest Destination, t time.Time) Event {
+	return Event{
+		Action:       EventActionRejection,
+		EventDetails: EventDetails{UserId: user, Destination: dest},
+		Time:         t,
 	}
 }

--- a/internal/types/main_test.go
+++ b/internal/types/main_test.go
@@ -54,6 +54,40 @@ func TestFileEvents_Approvals(t *testing.T) {
 			events:   FileEvents{approve(user1, dest1), approve(user2, dest1), reject(user1, dest1), approve(user1, dest2)},
 			expected: FileApprovals{{UserId: user2, Destination: dest1}, {UserId: user1, Destination: dest2}},
 		},
+		{
+			// Regression for #78: the latest approval's comment must win
+			name: "approve, reject, approve keeps latest comment",
+			events: FileEvents{
+				approveWithComment(user1, dest1, "first"),
+				rejectWithComment(user1, dest1, "second"),
+				approveWithComment(user1, dest1, "third"),
+			},
+			expected: FileApprovals{{UserId: user1, Destination: dest1, Comment: "third"}},
+		},
+		{
+			// Regression for #78: consecutive approvals keep the latest comment
+			name: "approve, approve keeps latest comment",
+			events: FileEvents{
+				approveWithComment(user1, dest1, "first"),
+				approveWithComment(user1, dest1, "second"),
+			},
+			expected: FileApprovals{{UserId: user1, Destination: dest1, Comment: "second"}},
+		},
+		{
+			// Distinct comments per key, preserving first-appearance ordering
+			name: "multiple keys keep their own latest comments in order",
+			events: FileEvents{
+				approveWithComment(user1, dest1, "u1d1-a"),
+				approveWithComment(user2, dest1, "u2d1-a"),
+				reject(user1, dest1),
+				approveWithComment(user1, dest1, "u1d1-b"),
+				approveWithComment(user2, dest1, "u2d1-b"),
+			},
+			expected: FileApprovals{
+				{UserId: user1, Destination: dest1, Comment: "u1d1-b"},
+				{UserId: user2, Destination: dest1, Comment: "u2d1-b"},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -63,22 +97,30 @@ func TestFileEvents_Approvals(t *testing.T) {
 }
 
 func approve(user UserId, dest Destination) Event {
-	return Event{
-		Action:       EventActionApproval,
-		EventDetails: EventDetails{UserId: user, Destination: dest},
-	}
+	return approveWithComment(user, dest, "")
 }
 
 func reject(user UserId, dest Destination) Event {
-	return Event{
-		Action:       EventActionRejection,
-		EventDetails: EventDetails{UserId: user, Destination: dest},
-	}
+	return rejectWithComment(user, dest, "")
 }
 
 func download(user UserId, dest Destination) Event {
 	return Event{
 		Action:       EventActionDownload,
 		EventDetails: EventDetails{UserId: user, Destination: dest},
+	}
+}
+
+func approveWithComment(user UserId, dest Destination, comment string) Event {
+	return Event{
+		Action:       EventActionApproval,
+		EventDetails: EventDetails{UserId: user, Destination: dest, Comment: comment},
+	}
+}
+
+func rejectWithComment(user UserId, dest Destination, comment string) Event {
+	return Event{
+		Action:       EventActionRejection,
+		EventDetails: EventDetails{UserId: user, Destination: dest, Comment: comment},
 	}
 }


### PR DESCRIPTION
## Resolves #78 

- Fixes the approval comment ordering so that the last comment is shown, instead of the first
- Strengthen unit tests to avoid regression
- Prepare release of 1.2.0

### Checklist

- [x] Documentation has been updated
- [x] [e2e tests](https://github.com/ucl-arc-tre/egress/tree/main/e2e) have been added/updated, if required
- [NA] Migration path is described, if required

### Risk assessment

<!--
If the risk score is non-zero please add a 'risk' label to the PR along
with the associated risk areas. See https://isms.arc.ucl.ac.uk/rism04-risk_assessment_and_treatment_procedure for guidance on risk assessing.

Impact is scored 0-5 with 0 being no impact and 5 being financial loss of >£15m and/or significant reputational damage to the institution.

Likelihood is scored 0-5 with 0 being impossible, 3 meaning it could occur in 2 years, and 5 being risk is occurring now.

If the risk score (Impact x Likelihood + Impact) exceeds 9 then this PR cannot be merged
unless accepted by risk management groups at all institutions.
-->

Statement: bug fix, no impact
Impact: 0
Likelihood: NA
