### PR TITLE
fix: Allow auth.bearer to be `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install using [helm](https://helm.sh/)
 
 ```bash
 helm install egress oci://ghcr.io/ucl-arc-tre/charts/egress \
-  --version 1.2.0
+  --version 1.2.1
 ```
 
 See [chart/values.yaml](./chart/values.yaml) for values.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install using [helm](https://helm.sh/)
 
 ```bash
 helm install egress oci://ghcr.io/ucl-arc-tre/charts/egress \
-  --version 1.2.1
+  --version 1.3.0
 ```
 
 See [chart/values.yaml](./chart/values.yaml) for values.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: egress
 description: Helm chart for deploying the UCL ARC TRE egress service
 type: application
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.2.1
+appVersion: 1.2.1

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: egress
 description: Helm chart for deploying the UCL ARC TRE egress service
 type: application
-version: 1.2.1
-appVersion: 1.2.1
+version: 1.3.0
+appVersion: 1.3.0

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -32,7 +32,7 @@ stringData:
         username: {{ required "db.rqlite.username is required" .Values.db.rqlite.username }}
         password: {{ required "db.rqlite.password is required" .Values.db.rqlite.password }}
       {{- end }}
-    {{- if not .Values.auth }}
+    {{- if or (not .Values.auth) (and (eq .Values.auth.basic nil) (eq .Values.auth.bearer nil)) }}
     {{- fail "auth is required; provide at least one of auth.basic or auth.bearer" }}
     {{- end }}
     {{- if not (or (hasKey .Values.auth "basic") (hasKey .Values.auth "bearer")) }}
@@ -47,8 +47,8 @@ stringData:
         username: {{ required "auth.basic.username is required" .Values.auth.basic.username }}
         password: {{ required "auth.basic.password is required" .Values.auth.basic.password }}
       {{- end }}
-      {{- if hasKey .Values.auth "bearer" }}
-      {{- if not .Values.auth.bearer }}
+      {{- if and (hasKey .Values.auth "bearer") (ne .Values.auth.bearer nil) }}
+      {{- if and (not (hasKey .Values.auth.bearer "audience")) (not (hasKey .Values.auth.bearer "issuer_url")) }}
       {{- fail "auth.bearer is set but empty; either remove it or provide auth.bearer.issuer_url and auth.bearer.audience" }}
       {{- end }}
       bearer:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -32,11 +32,14 @@ stringData:
         username: {{ required "db.rqlite.username is required" .Values.db.rqlite.username }}
         password: {{ required "db.rqlite.password is required" .Values.db.rqlite.password }}
       {{- end }}
-    {{- if or (not .Values.auth) (and (eq .Values.auth.basic nil) (eq .Values.auth.bearer nil)) }}
+    {{- if not .Values.auth}}
     {{- fail "auth is required; provide at least one of auth.basic or auth.bearer" }}
     {{- end }}
     {{- if not (or (hasKey .Values.auth "basic") (hasKey .Values.auth "bearer")) }}
     {{- fail "auth supports only auth.basic and auth.bearer" }}
+    {{- end }}
+    {{- if and (eq .Values.auth.basic nil) (eq .Values.auth.bearer nil) }}
+    {{- fail "at least one of auth.basic or auth.bearer must be non-nil" }}
     {{- end }}
     auth:
       {{- if and (hasKey .Values.auth "basic") (ne .Values.auth.basic nil) }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -39,7 +39,7 @@ stringData:
     {{- fail "auth supports only auth.basic and auth.bearer" }}
     {{- end }}
     auth:
-      {{- if hasKey .Values.auth "basic" }}
+      {{- if and (hasKey .Values.auth "basic") (ne .Values.auth.basic nil) }}
       {{- if not .Values.auth.basic }}
       {{- fail "auth.basic is set but empty; either remove it or provide auth.basic.username and auth.basic.password" }}
       {{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -43,16 +43,16 @@ stringData:
     {{- end }}
     auth:
       {{- if and (hasKey .Values.auth "basic") (ne .Values.auth.basic nil) }}
-      {{- if not .Values.auth.basic }}
-      {{- fail "auth.basic is set but empty; either remove it or provide auth.basic.username and auth.basic.password" }}
+      {{- if or (not .Values.auth.basic) (not (kindIs "map" .Values.auth.basic)) }}
+      {{- fail "auth.basic is set but invalid; either remove it or provide auth.basic.username and auth.basic.password" }}
       {{- end }}
       basic:
         username: {{ required "auth.basic.username is required" .Values.auth.basic.username }}
         password: {{ required "auth.basic.password is required" .Values.auth.basic.password }}
       {{- end }}
       {{- if and (hasKey .Values.auth "bearer") (ne .Values.auth.bearer nil) }}
-      {{- if and (not (hasKey .Values.auth.bearer "audience")) (not (hasKey .Values.auth.bearer "issuer_url")) }}
-      {{- fail "auth.bearer is set but empty; either remove it or provide auth.bearer.issuer_url and auth.bearer.audience" }}
+      {{- if or (not .Values.auth.bearer) (not (kindIs "map" .Values.auth.bearer)) }}
+      {{- fail "auth.bearer is set but invalid; either remove it or provide auth.bearer.issuer_url and auth.bearer.audience" }}
       {{- end }}
       bearer:
         issuer_url: {{ required "auth.bearer.issuer_url is required" .Values.auth.bearer.issuer_url }}


### PR DESCRIPTION

<!--
Summary
-->
Fixes a bug where setting `auth.bearer` or `auth.basic` to `null` explicitly makes the helm chart fail, even if the other `auth` is set.

### Checklist

- [x] Documentation has been updated
- [x] [e2e tests](https://github.com/ucl-arc-tre/egress/tree/main/e2e) have been added/updated, if required
- [x] Migration path is described, if required

### Risk assessment

<!--
If the risk score is non-zero please add a 'risk' label to the PR along
with the associated risk areas. See https://isms.arc.ucl.ac.uk/rism04-risk_assessment_and_treatment_procedure for guidance on risk assessing.

Impact is scored 0-5 with 0 being no impact and 5 being financial loss of >£15m and/or significant reputational damage to the institution.

Likelihood is scored 0-5 with 0 being impossible, 3 meaning it could occur in 2 years, and 5 being risk is occurring now.

If the risk score (Impact x Likelihood + Impact) exceeds 9 then this PR cannot be merged
unless accepted by risk management groups at all institutions.
-->

Statement: bug fix, no impact
Impact: 0
Likelihood: NA
