### PR TITLE
harden github actions and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,30 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
+  - package-ecosystem: 'github-actions'
+    directory: '.github/workflows'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
-          - "*"
+          - '*'
 
-  - package-ecosystem: "docker"
+  - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'docker'
+    directory: /
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: 'monthly'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -3,9 +3,9 @@ name: Image
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     tags:
-      - "*"
+      - '*'
 
 env:
   REGISTRY: ghcr.io
@@ -18,9 +18,11 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -28,7 +30,7 @@ jobs:
 
       - name: Extract tags and labels for image
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
@@ -36,9 +38,9 @@ jobs:
             type=semver,pattern={{version}}
           flavor: latest=true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,19 +11,23 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # version 7.0.0
         with:
-          python-version: "3.13"
+          persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # version 6.3.0, See: https://github.com/actions/setup-python/releases
         with:
-          go-version: "1.25"
+          python-version: '3.13'
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # version 6.5.0, See: https://github.com/actions/setup-go/releases
+        with:
+          go-version: '1.25'
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # version 3.0.1, See: https://github.com/pre-commit/action/releases
         with:
           extra_args: --all-files

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,7 @@ name: Publish
 on:
   push:
     tags:
-      - "*"
+      - '*'
 
 env:
   REGISTRY: ghcr.io
@@ -17,7 +17,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Login
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ name: Security
 on:
   pull_request:
     paths:
-      - "**.go"
+      - '**.go'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,13 +13,17 @@ concurrency:
 jobs:
   gosec:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GO111MODULE: on
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
         with:
-          args: "./..."
+          args: './...'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,21 +3,22 @@ name: Test
 on:
   pull_request:
     paths-ignore:
-      - "docs/**"
+      - 'docs/**'
 
 jobs:
   unit:
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # version 7.0.0
         with:
-          go-version: "1.25"
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # version 6.5.0, See: https://github.com/actions/setup-go/releases
+        with:
+          go-version: '1.25'
 
       - name: Run unit tests
         run: make test-unit
@@ -25,16 +26,17 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: [unit]
-
     permissions:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # version 7.0.0
         with:
-          go-version: "1.25"
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # version 6.5.0, See: https://github.com/actions/setup-go/releases
+        with:
+          go-version: '1.25'
 
       - name: Install k3d
         run: |


### PR DESCRIPTION
Hardens the Github actions CI by pinning versions and reducing permissions, and adds dependabot updates with a cooldown

### Checklist

- n/a Documentation has been updated
- [x] [e2e tests](https://github.com/ucl-arc-tre/egress/tree/main/e2e) have been added/updated, if required
- [x] Migration path is described, if required

### Risk assessment

Statement: Reduces risk
Impact: n/a
Likelihood: n/a